### PR TITLE
fix: canceled should always be set totrue when cancel a watch request

### DIFF
--- a/pkg/logstructured/logstructured.go
+++ b/pkg/logstructured/logstructured.go
@@ -2,7 +2,6 @@ package logstructured
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"time"
 
@@ -454,7 +453,7 @@ func (l *LogStructured) Watch(ctx context.Context, prefix string, revision int64
 			wr.CompactRevision = compact
 			wr.CurrentRevision = rev
 		} else {
-			errorc <- errors.New("failed to execute query in database")
+			errorc <- server.ErrGRPCUnhealthy
 		}
 		cancel()
 	}

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -82,6 +82,7 @@ type WatchResult struct {
 	CurrentRevision int64
 	CompactRevision int64
 	Events          <-chan []*Event
+	Errorc          <-chan error
 }
 
 func unsupported(field string) error {

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -12,9 +12,10 @@ import (
 var (
 	ErrNotSupported = status.New(codes.InvalidArgument, "etcdserver: unsupported operations in txn request").Err()
 
-	ErrKeyExists = rpctypes.ErrGRPCDuplicateKey
-	ErrCompacted = rpctypes.ErrGRPCCompacted
-	ErrFutureRev = rpctypes.ErrGRPCFutureRev
+	ErrKeyExists     = rpctypes.ErrGRPCDuplicateKey
+	ErrCompacted     = rpctypes.ErrGRPCCompacted
+	ErrFutureRev     = rpctypes.ErrGRPCFutureRev
+	ErrGRPCUnhealthy = rpctypes.ErrGRPCUnhealthy
 )
 
 type Backend interface {

--- a/pkg/server/watch.go
+++ b/pkg/server/watch.go
@@ -161,7 +161,12 @@ func (w *watcher) Start(ctx context.Context, r *etcdserverpb.WatchCreateRequest)
 				}
 			}
 		}
-		w.Cancel(id, 0, 0, nil)
+		select {
+		case err := <-wr.Errorc:
+			w.Cancel(id, 0, 0, err)
+		default:
+			w.Cancel(id, 0, 0, nil)
+		}
 		logrus.Tracef("WATCH CLOSE id=%d, key=%s", id, key)
 	}()
 }
@@ -205,7 +210,7 @@ func (w *watcher) Cancel(watchID, revision, compactRev int64, err error) {
 
 	serr := w.server.Send(&etcdserverpb.WatchResponse{
 		Header:          txnHeader(revision),
-		Canceled:        err != nil,
+		Canceled:        true,
 		CancelReason:    reason,
 		WatchId:         watchID,
 		CompactRevision: compactRev,


### PR DESCRIPTION
backport https://github.com/k3s-io/kine/pull/373 