### PR TITLE
feat: support externally managed sql.DB for postgres backend

### DIFF
--- a/pkg/drivers/generic/generic.go
+++ b/pkg/drivers/generic/generic.go
@@ -223,6 +223,9 @@ func Open(ctx context.Context, driverName, dataSourceName string, connPoolConfig
 		case <-time.After(time.Second):
 		}
 	}
+	if err != nil {
+		return nil, err
+	}
 
 	return OpenWithDB(db, connPoolConfig, paramCharacter, numbered, metricsRegisterer, driverName)
 }

--- a/pkg/drivers/generic/generic.go
+++ b/pkg/drivers/generic/generic.go
@@ -224,6 +224,13 @@ func Open(ctx context.Context, driverName, dataSourceName string, connPoolConfig
 		}
 	}
 
+	return OpenWithDB(db, connPoolConfig, paramCharacter, numbered, metricsRegisterer, driverName)
+}
+
+// OpenWithDB initializes a Generic dialect using an externally provided *sql.DB,
+// skipping the internal openAndTest retry loop. This allows callers that manage
+// their own database connections (e.g. with credential rotation) to inject them.
+func OpenWithDB(db *sql.DB, connPoolConfig ConnectionPoolConfig, paramCharacter string, numbered bool, metricsRegisterer prometheus.Registerer, driverName string) (*Generic, error) {
 	configureConnectionPooling(connPoolConfig, db, driverName)
 
 	if metricsRegisterer != nil {
@@ -279,7 +286,7 @@ func Open(ctx context.Context, driverName, dataSourceName string, connPoolConfig
 
 		FillSQL: q(`INSERT INTO kine(id, name, created, deleted, create_revision, prev_revision, lease, value, old_value)
 			values(?, ?, ?, ?, ?, ?, ?, ?, ?)`, paramCharacter, numbered),
-	}, err
+	}, nil
 }
 
 func (d *Generic) query(ctx context.Context, sql string, args ...interface{}) (result *sql.Rows, err error) {

--- a/pkg/drivers/pgsql/pgsql.go
+++ b/pkg/drivers/pgsql/pgsql.go
@@ -63,6 +63,35 @@ func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config, connPoo
 	if err != nil {
 		return nil, err
 	}
+	configureDialect(dialect)
+
+	if err := setup(dialect.DB); err != nil {
+		return nil, err
+	}
+
+	dialect.Migrate(context.Background())
+	return logstructured.New(sqllog.New(dialect)), nil
+}
+
+// NewWithDB creates a PostgreSQL backend using an externally managed *sql.DB,
+// skipping DSN parsing and database auto-creation. The caller is responsible
+// for the lifecycle of the provided connection.
+func NewWithDB(db *sql.DB, connPoolConfig generic.ConnectionPoolConfig, metricsRegisterer prometheus.Registerer) (server.Backend, error) {
+	dialect, err := generic.OpenWithDB(db, connPoolConfig, "$", true, metricsRegisterer, "pgx")
+	if err != nil {
+		return nil, err
+	}
+	configureDialect(dialect)
+
+	if err := setup(dialect.DB); err != nil {
+		return nil, err
+	}
+
+	dialect.Migrate(context.Background())
+	return logstructured.New(sqllog.New(dialect)), nil
+}
+
+func configureDialect(dialect *generic.Generic) {
 	dialect.GetSizeSQL = `SELECT pg_total_relation_size('kine')`
 	dialect.CompactSQL = `
 		DELETE FROM kine AS kv
@@ -103,13 +132,6 @@ func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config, connPoo
 		}
 		return err.Error()
 	}
-
-	if err := setup(dialect.DB); err != nil {
-		return nil, err
-	}
-
-	dialect.Migrate(context.Background())
-	return logstructured.New(sqllog.New(dialect)), nil
 }
 
 func setup(db *sql.DB) error {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2,6 +2,7 @@ package endpoint
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"net"
 	"os"
@@ -48,6 +49,7 @@ type Config struct {
 	ServerTLSConfig      tls.Config
 	BackendTLSConfig     tls.Config
 	MetricsRegisterer    prometheus.Registerer
+	DB                   *sql.DB // optional: externally managed DB connection (skips internal sql.Open)
 }
 
 type ETCDConfig struct {
@@ -205,6 +207,16 @@ func grpcServer(config Config) (*grpc.Server, error) {
 // indicating whether the backend requires leader election, and a suitable
 // backend datastore connection.
 func getKineStorageBackend(ctx context.Context, driver, dsn string, cfg Config) (bool, server.Backend, error) {
+	if cfg.DB != nil {
+		switch driver {
+		case PostgresBackend:
+			backend, err := pgsql.NewWithDB(cfg.DB, cfg.ConnectionPoolConfig, cfg.MetricsRegisterer)
+			return true, backend, err
+		default:
+			return false, nil, fmt.Errorf("external DB injection is only supported for postgres backend")
+		}
+	}
+
 	var (
 		backend     server.Backend
 		leaderElect = true


### PR DESCRIPTION
- Add support for initializing the Postgres backend with an externally managed `*sql.DB`.
- Introduce `generic.OpenWithDB(...)` and `pgsql.NewWithDB(...)` to skip internal DB open/retry flows when a DB handle is already managed by the caller.
- Extend endpoint config with an optional `DB` field and route backend initialization to the new path when provided.
