### PR TITLE
feat: add configurable poll interval

### DIFF
--- a/pkg/drivers/dqlite/dqlite.go
+++ b/pkg/drivers/dqlite/dqlite.go
@@ -69,7 +69,7 @@ outer:
 	return nil
 }
 
-func New(ctx context.Context, datasourceName string, connPoolConfig generic.ConnectionPoolConfig, metricsRegisterer prometheus.Registerer) (server.Backend, error) {
+func New(ctx context.Context, datasourceName string, connPoolConfig generic.ConnectionPoolConfig, metricsRegisterer prometheus.Registerer, pollInterval time.Duration) (server.Backend, error) {
 	opts, err := parseOpts(datasourceName)
 	if err != nil {
 		return nil, err
@@ -98,7 +98,7 @@ func New(ctx context.Context, datasourceName string, connPoolConfig generic.Conn
 	}
 
 	sql.Register("dqlite", d)
-	backend, generic, err := sqlite.NewVariant(ctx, "dqlite", opts.dsn, connPoolConfig, metricsRegisterer)
+	backend, generic, err := sqlite.NewVariant(ctx, "dqlite", opts.dsn, connPoolConfig, metricsRegisterer, pollInterval)
 	if err != nil {
 		return nil, errors.Wrap(err, "sqlite client")
 	}

--- a/pkg/drivers/dqlite/no_dqlite.go
+++ b/pkg/drivers/dqlite/no_dqlite.go
@@ -6,12 +6,13 @@ package dqlite
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/k3s-io/kine/pkg/drivers/generic"
 	"github.com/k3s-io/kine/pkg/server"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func New(ctx context.Context, datasourceName string, connPoolConfig generic.ConnectionPoolConfig, metricsRegisterer prometheus.Registerer) (server.Backend, error) {
+func New(ctx context.Context, datasourceName string, connPoolConfig generic.ConnectionPoolConfig, metricsRegisterer prometheus.Registerer, pollInterval time.Duration) (server.Backend, error) {
 	return nil, errors.New(`this binary is built without dqlite support, compile with "-tags dqlite"`)
 }

--- a/pkg/drivers/mssql/mssql.go
+++ b/pkg/drivers/mssql/mssql.go
@@ -124,7 +124,7 @@ func q(sql string) string {
 	return string(result)
 }
 
-func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config, connPoolConfig generic.ConnectionPoolConfig, metricsRegisterer prometheus.Registerer) (server.Backend, error) {
+func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config, connPoolConfig generic.ConnectionPoolConfig, metricsRegisterer prometheus.Registerer, pollInterval time.Duration) (server.Backend, error) {
 	parsedDSN, err := prepareDSN(dataSourceName, tlsInfo)
 	if err != nil {
 		return nil, err
@@ -234,7 +234,7 @@ func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config, connPoo
 	}
 
 	dialect.Migrate(context.Background())
-	return logstructured.New(sqllog.New(dialect)), nil
+	return logstructured.New(sqllog.New(dialect, pollInterval)), nil
 }
 
 func setup(db *sql.DB) error {

--- a/pkg/drivers/mysql/mysql.go
+++ b/pkg/drivers/mysql/mysql.go
@@ -5,6 +5,7 @@ import (
 	cryptotls "crypto/tls"
 	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/prometheus/client_golang/prometheus"
@@ -47,7 +48,7 @@ var (
 	createDB = "CREATE DATABASE IF NOT EXISTS "
 )
 
-func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config, connPoolConfig generic.ConnectionPoolConfig, metricsRegisterer prometheus.Registerer) (server.Backend, error) {
+func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config, connPoolConfig generic.ConnectionPoolConfig, metricsRegisterer prometheus.Registerer, pollInterval time.Duration) (server.Backend, error) {
 	tlsConfig, err := tlsInfo.ClientConfig()
 	if err != nil {
 		return nil, err
@@ -113,7 +114,7 @@ func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config, connPoo
 	}
 
 	dialect.Migrate(context.Background())
-	return logstructured.New(sqllog.New(dialect)), nil
+	return logstructured.New(sqllog.New(dialect, pollInterval)), nil
 }
 
 func setup(db *sql.DB) error {

--- a/pkg/drivers/panwei/panwei.go
+++ b/pkg/drivers/panwei/panwei.go
@@ -41,7 +41,7 @@ var (
 	}
 )
 
-func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config, connPoolConfig generic.ConnectionPoolConfig, metricsRegisterer prometheus.Registerer) (server.Backend, error) {
+func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config, connPoolConfig generic.ConnectionPoolConfig, metricsRegisterer prometheus.Registerer, pollInterval time.Duration) (server.Backend, error) {
 	parsedDSN, err := prepareDSN(dataSourceName, tlsInfo)
 	if err != nil {
 		return nil, err
@@ -97,7 +97,7 @@ func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config, connPoo
 	}
 
 	dialect.Migrate(context.Background())
-	return logstructured.New(sqllog.New(dialect)), nil
+	return logstructured.New(sqllog.New(dialect, pollInterval)), nil
 }
 
 func setup(db *sql.DB) error {

--- a/pkg/drivers/pgsql/pgsql.go
+++ b/pkg/drivers/pgsql/pgsql.go
@@ -49,7 +49,7 @@ var (
 	createDB = "CREATE DATABASE "
 )
 
-func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config, connPoolConfig generic.ConnectionPoolConfig, metricsRegisterer prometheus.Registerer) (server.Backend, error) {
+func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config, connPoolConfig generic.ConnectionPoolConfig, metricsRegisterer prometheus.Registerer, pollInterval time.Duration) (server.Backend, error) {
 	parsedDSN, err := prepareDSN(dataSourceName, tlsInfo)
 	if err != nil {
 		return nil, err
@@ -70,13 +70,13 @@ func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config, connPoo
 	}
 
 	dialect.Migrate(context.Background())
-	return logstructured.New(sqllog.New(dialect)), nil
+	return logstructured.New(sqllog.New(dialect, pollInterval)), nil
 }
 
 // NewWithDB creates a PostgreSQL backend using an externally managed *sql.DB,
 // skipping DSN parsing and database auto-creation. The caller is responsible
 // for the lifecycle of the provided connection.
-func NewWithDB(db *sql.DB, connPoolConfig generic.ConnectionPoolConfig, metricsRegisterer prometheus.Registerer) (server.Backend, error) {
+func NewWithDB(db *sql.DB, connPoolConfig generic.ConnectionPoolConfig, metricsRegisterer prometheus.Registerer, pollInterval time.Duration) (server.Backend, error) {
 	dialect, err := generic.OpenWithDB(db, connPoolConfig, "$", true, metricsRegisterer, "pgx")
 	if err != nil {
 		return nil, err
@@ -88,7 +88,7 @@ func NewWithDB(db *sql.DB, connPoolConfig generic.ConnectionPoolConfig, metricsR
 	}
 
 	dialect.Migrate(context.Background())
-	return logstructured.New(sqllog.New(dialect)), nil
+	return logstructured.New(sqllog.New(dialect, pollInterval)), nil
 }
 
 func configureDialect(dialect *generic.Generic) {

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -47,12 +47,12 @@ var (
 	}
 )
 
-func New(ctx context.Context, dataSourceName string, connPoolConfig generic.ConnectionPoolConfig, metricsRegisterer prometheus.Registerer) (server.Backend, error) {
-	backend, _, err := NewVariant(ctx, "sqlite3", dataSourceName, connPoolConfig, metricsRegisterer)
+func New(ctx context.Context, dataSourceName string, connPoolConfig generic.ConnectionPoolConfig, metricsRegisterer prometheus.Registerer, pollInterval time.Duration) (server.Backend, error) {
+	backend, _, err := NewVariant(ctx, "sqlite3", dataSourceName, connPoolConfig, metricsRegisterer, pollInterval)
 	return backend, err
 }
 
-func NewVariant(ctx context.Context, driverName, dataSourceName string, connPoolConfig generic.ConnectionPoolConfig, metricsRegisterer prometheus.Registerer) (server.Backend, *generic.Generic, error) {
+func NewVariant(ctx context.Context, driverName, dataSourceName string, connPoolConfig generic.ConnectionPoolConfig, metricsRegisterer prometheus.Registerer, pollInterval time.Duration) (server.Backend, *generic.Generic, error) {
 	if dataSourceName == "" {
 		if err := os.MkdirAll("./db", 0700); err != nil {
 			return nil, nil, err
@@ -121,7 +121,7 @@ func NewVariant(ctx context.Context, driverName, dataSourceName string, connPool
 	}
 
 	dialect.Migrate(context.Background())
-	return logstructured.New(sqllog.New(dialect)), dialect, nil
+	return logstructured.New(sqllog.New(dialect, pollInterval)), dialect, nil
 }
 
 func setup(db *sql.DB) error {

--- a/pkg/drivers/sqlite/sqlite_nocgo.go
+++ b/pkg/drivers/sqlite/sqlite_nocgo.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"time"
 
 	"github.com/k3s-io/kine/pkg/drivers/generic"
 	"github.com/k3s-io/kine/pkg/server"
@@ -15,11 +16,11 @@ import (
 
 var errNoCgo = errors.New("this binary is built without CGO, sqlite is disabled")
 
-func New(ctx context.Context, dataSourceName string, connPoolConfig generic.ConnectionPoolConfig, metricsRegisterer prometheus.Registerer) (server.Backend, error) {
+func New(ctx context.Context, dataSourceName string, connPoolConfig generic.ConnectionPoolConfig, metricsRegisterer prometheus.Registerer, pollInterval time.Duration) (server.Backend, error) {
 	return nil, errNoCgo
 }
 
-func NewVariant(driverName, dataSourceName string, connPoolConfig generic.ConnectionPoolConfig, metricsRegisterer prometheus.Registerer) (server.Backend, *generic.Generic, error) {
+func NewVariant(ctx context.Context, driverName, dataSourceName string, connPoolConfig generic.ConnectionPoolConfig, metricsRegisterer prometheus.Registerer, pollInterval time.Duration) (server.Backend, *generic.Generic, error) {
 	return nil, nil, errNoCgo
 }
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -65,8 +65,12 @@ func Listen(ctx context.Context, config Config) (ETCDConfig, error) {
 
 	if config.PollInterval == 0 {
 		if v := os.Getenv("KINE_POLL_INTERVAL"); v != "" {
-			if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			if d, err := time.ParseDuration(v); err != nil {
+				logrus.Warnf("invalid KINE_POLL_INTERVAL %q: %v; using default", v, err)
+			} else if d > 0 {
 				config.PollInterval = d
+			} else {
+				logrus.Warnf("non-positive KINE_POLL_INTERVAL %q; using default", v)
 			}
 		}
 	}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/k3s-io/kine/pkg/drivers/dqlite"
 	"github.com/k3s-io/kine/pkg/drivers/generic"
@@ -50,6 +51,7 @@ type Config struct {
 	BackendTLSConfig     tls.Config
 	MetricsRegisterer    prometheus.Registerer
 	DB                   *sql.DB // optional: externally managed DB connection (skips internal sql.Open)
+	PollInterval         time.Duration
 }
 
 type ETCDConfig struct {
@@ -60,6 +62,18 @@ type ETCDConfig struct {
 
 func Listen(ctx context.Context, config Config) (ETCDConfig, error) {
 	driver, dsn := ParseStorageEndpoint(config.Endpoint)
+
+	if config.PollInterval == 0 {
+		if v := os.Getenv("KINE_POLL_INTERVAL"); v != "" {
+			if d, err := time.ParseDuration(v); err == nil && d > 0 {
+				config.PollInterval = d
+			}
+		}
+	}
+	if config.PollInterval == 0 {
+		config.PollInterval = time.Second
+	}
+
 	if driver == ETCDBackend {
 		return ETCDConfig{
 			Endpoints:   strings.Split(config.Endpoint, ","),
@@ -210,7 +224,7 @@ func getKineStorageBackend(ctx context.Context, driver, dsn string, cfg Config) 
 	if cfg.DB != nil {
 		switch driver {
 		case PostgresBackend:
-			backend, err := pgsql.NewWithDB(cfg.DB, cfg.ConnectionPoolConfig, cfg.MetricsRegisterer)
+			backend, err := pgsql.NewWithDB(cfg.DB, cfg.ConnectionPoolConfig, cfg.MetricsRegisterer, cfg.PollInterval)
 			return true, backend, err
 		default:
 			return false, nil, fmt.Errorf("external DB injection is only supported for postgres backend")
@@ -225,17 +239,17 @@ func getKineStorageBackend(ctx context.Context, driver, dsn string, cfg Config) 
 	switch driver {
 	case SQLiteBackend:
 		leaderElect = false
-		backend, err = sqlite.New(ctx, dsn, cfg.ConnectionPoolConfig, cfg.MetricsRegisterer)
+		backend, err = sqlite.New(ctx, dsn, cfg.ConnectionPoolConfig, cfg.MetricsRegisterer, cfg.PollInterval)
 	case DQLiteBackend:
-		backend, err = dqlite.New(ctx, dsn, cfg.ConnectionPoolConfig, cfg.MetricsRegisterer)
+		backend, err = dqlite.New(ctx, dsn, cfg.ConnectionPoolConfig, cfg.MetricsRegisterer, cfg.PollInterval)
 	case PostgresBackend:
-		backend, err = pgsql.New(ctx, dsn, cfg.BackendTLSConfig, cfg.ConnectionPoolConfig, cfg.MetricsRegisterer)
+		backend, err = pgsql.New(ctx, dsn, cfg.BackendTLSConfig, cfg.ConnectionPoolConfig, cfg.MetricsRegisterer, cfg.PollInterval)
 	case PanweiBackend:
-		backend, err = panwei.New(ctx, dsn, cfg.BackendTLSConfig, cfg.ConnectionPoolConfig, cfg.MetricsRegisterer)
+		backend, err = panwei.New(ctx, dsn, cfg.BackendTLSConfig, cfg.ConnectionPoolConfig, cfg.MetricsRegisterer, cfg.PollInterval)
 	case MySQLBackend:
-		backend, err = mysql.New(ctx, dsn, cfg.BackendTLSConfig, cfg.ConnectionPoolConfig, cfg.MetricsRegisterer)
+		backend, err = mysql.New(ctx, dsn, cfg.BackendTLSConfig, cfg.ConnectionPoolConfig, cfg.MetricsRegisterer, cfg.PollInterval)
 	case MSSQLBackend:
-		backend, err = mssql.New(ctx, dsn, cfg.BackendTLSConfig, cfg.ConnectionPoolConfig, cfg.MetricsRegisterer)
+		backend, err = mssql.New(ctx, dsn, cfg.BackendTLSConfig, cfg.ConnectionPoolConfig, cfg.MetricsRegisterer, cfg.PollInterval)
 	case JetStreamBackend:
 		backend, err = nats.NewLegacy(ctx, dsn, cfg.BackendTLSConfig)
 	case NATSBackend:

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -64,17 +64,6 @@ func Listen(ctx context.Context, config Config) (ETCDConfig, error) {
 	driver, dsn := ParseStorageEndpoint(config.Endpoint)
 
 	if config.PollInterval == 0 {
-		if v := os.Getenv("KINE_POLL_INTERVAL"); v != "" {
-			if d, err := time.ParseDuration(v); err != nil {
-				logrus.Warnf("invalid KINE_POLL_INTERVAL %q: %v; using default", v, err)
-			} else if d > 0 {
-				config.PollInterval = d
-			} else {
-				logrus.Warnf("non-positive KINE_POLL_INTERVAL %q; using default", v)
-			}
-		}
-	}
-	if config.PollInterval == 0 {
 		config.PollInterval = time.Second
 	}
 

--- a/pkg/logstructured/sqllog/sql.go
+++ b/pkg/logstructured/sqllog/sql.go
@@ -22,16 +22,21 @@ const (
 )
 
 type SQLLog struct {
-	d           server.Dialect
-	broadcaster broadcaster.Broadcaster
-	ctx         context.Context
-	notify      chan int64
+	d            server.Dialect
+	broadcaster  broadcaster.Broadcaster
+	ctx          context.Context
+	notify       chan int64
+	pollInterval time.Duration
 }
 
-func New(d server.Dialect) *SQLLog {
+func New(d server.Dialect, pollInterval time.Duration) *SQLLog {
+	if pollInterval <= 0 {
+		pollInterval = time.Second
+	}
 	l := &SQLLog{
-		d:      d,
-		notify: make(chan int64, 1024),
+		d:            d,
+		notify:       make(chan int64, 1024),
+		pollInterval: pollInterval,
 	}
 	return l
 }
@@ -415,7 +420,7 @@ func (s *SQLLog) poll(result chan interface{}, pollStart int64) {
 		waitForMore = true
 	)
 
-	wait := time.NewTicker(time.Second)
+	wait := time.NewTicker(s.pollInterval)
 	defer wait.Stop()
 	defer close(result)
 


### PR DESCRIPTION
## Summary

Add a configurable poll interval to kine's database polling loop (previously hardcoded to 1 second).

### Changes

- Added `PollInterval time.Duration` field to `endpoint.Config`
- Environment variable `KINE_POLL_INTERVAL` support (parsed as Go duration, e.g. `500ms`, `2s`)
- Threaded poll interval through all SQL driver `New()`/`NewWithDB()` functions to `sqllog.SQLLog`
- Defaults to 1 second when not configured (backward compatible)

### Drivers updated
- pgsql (New + NewWithDB)
- mysql
- mssql
- sqlite (+ nocgo stub)
- dqlite (+ no_dqlite stub)
- panwei
- NATS drivers: **not changed** (use a different backend, not sqllog)

### Testing
- `go build -tags nats ./...` passes
- No existing unit tests for affected packages; behavior is backward compatible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable polling interval for database watch/log polling across all backends, exposed as a new service configuration field.
  * Polling defaults to 1s when unset or invalid; the selected interval is applied by the service and passed to each database backend to control watch frequency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->