### PR TITLE
Backport TTL watch revision fix

### DIFF
--- a/pkg/logstructured/logstructured.go
+++ b/pkg/logstructured/logstructured.go
@@ -362,7 +362,6 @@ func (l *LogStructured) ttlEvents(ctx context.Context) chan *server.Event {
 
 	go func() {
 		defer wg.Done()
-		var lastRev int64
 
 		rev, events, err := l.log.List(ctx, "/", "", 1000, 0, false)
 		for len(events) > 0 {
@@ -375,15 +374,11 @@ func (l *LogStructured) ttlEvents(ctx context.Context) chan *server.Event {
 				if event.KV.Lease > 0 {
 					result <- event
 				}
-
-				if event.KV.ModRevision > lastRev {
-					lastRev = event.KV.ModRevision
-				}
 			}
 
-			_, events, err = l.log.List(ctx, "/", events[len(events)-1].KV.Key, 1000, rev, false)
+			rev, events, err = l.log.List(ctx, "/", events[len(events)-1].KV.Key, 1000, rev, false)
 		}
-		lastListRevision <- lastRev
+		lastListRevision <- rev
 	}()
 
 	go func() {

--- a/pkg/logstructured/logstructured_test.go
+++ b/pkg/logstructured/logstructured_test.go
@@ -75,15 +75,23 @@ func TestTTLEventsWatchStartsAtCurrentListRevision(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
+	ch := l.ttlEvents(ctx)
 	var events []*server.Event
-	for event := range l.ttlEvents(ctx) {
-		events = append(events, event)
-	}
-
-	if len(events) != 1 {
-		t.Fatalf("expected one TTL event from list, got %d", len(events))
-	}
-	if log.afterRevision != 9 {
-		t.Fatalf("expected watch After revision 9, got %d", log.afterRevision)
+	for {
+		select {
+		case event, ok := <-ch:
+			if !ok {
+				if len(events) != 1 {
+					t.Fatalf("expected one TTL event from list, got %d", len(events))
+				}
+				if log.afterRevision != 9 {
+					t.Fatalf("expected watch After revision 9, got %d", log.afterRevision)
+				}
+				return
+			}
+			events = append(events, event)
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		}
 	}
 }

--- a/pkg/logstructured/logstructured_test.go
+++ b/pkg/logstructured/logstructured_test.go
@@ -1,0 +1,89 @@
+package logstructured
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/k3s-io/kine/pkg/server"
+)
+
+type ttlWatchLog struct {
+	listCalls     int
+	afterRevision int64
+	compactRev    int64
+}
+
+func (l *ttlWatchLog) Start(ctx context.Context) error {
+	return nil
+}
+
+func (l *ttlWatchLog) CompactRevision(ctx context.Context) (int64, error) {
+	return l.compactRev, nil
+}
+
+func (l *ttlWatchLog) CurrentRevision(ctx context.Context) (int64, error) {
+	return 10, nil
+}
+
+func (l *ttlWatchLog) List(ctx context.Context, prefix, startKey string, limit, revision int64, includeDeletes bool) (int64, []*server.Event, error) {
+	l.listCalls++
+	if l.listCalls == 1 {
+		return 10, []*server.Event{
+			{
+				KV: &server.KeyValue{
+					Key:         "/old",
+					ModRevision: 5,
+					Lease:       60,
+				},
+			},
+		}, nil
+	}
+	return 10, nil, nil
+}
+
+func (l *ttlWatchLog) After(ctx context.Context, prefix string, revision, limit int64) (int64, []*server.Event, error) {
+	l.afterRevision = revision
+	if revision < l.compactRev {
+		return 10, nil, server.ErrCompacted
+	}
+	return 10, nil, nil
+}
+
+func (l *ttlWatchLog) Watch(ctx context.Context, prefix string) <-chan []*server.Event {
+	ch := make(chan []*server.Event)
+	close(ch)
+	return ch
+}
+
+func (l *ttlWatchLog) Count(ctx context.Context, prefix string) (int64, int64, error) {
+	return 0, 0, nil
+}
+
+func (l *ttlWatchLog) Append(ctx context.Context, event *server.Event) (int64, error) {
+	return 0, nil
+}
+
+func (l *ttlWatchLog) DbSize(ctx context.Context) (int64, error) {
+	return 0, nil
+}
+
+func TestTTLEventsWatchStartsAtCurrentListRevision(t *testing.T) {
+	log := &ttlWatchLog{compactRev: 8}
+	l := New(log)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	var events []*server.Event
+	for event := range l.ttlEvents(ctx) {
+		events = append(events, event)
+	}
+
+	if len(events) != 1 {
+		t.Fatalf("expected one TTL event from list, got %d", len(events))
+	}
+	if log.afterRevision != 9 {
+		t.Fatalf("expected watch After revision 9, got %d", log.afterRevision)
+	}
+}


### PR DESCRIPTION
Backport k3s-io/kine@b527bdd60620cd30d34ac10cb30221abc0f54edd so the internal TTL watcher starts from the list response revision instead of the max visible KV revision. This avoids restarting the watcher from a revision that may already be compacted when visible keys are old but the global revision has moved forward.

I also added a regression test for the case where the visible key mod revision is lower than the compact revision, while the list response revision is still current. The test uses its own context timeout while reading from ttlEvents so channel-close regressions fail quickly.

Fixes #12

Tested with:

```
go test ./...
```